### PR TITLE
jms to rdmbs event flow

### DIFF
--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/ReadMe.txt
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/ReadMe.txt
@@ -1,0 +1,43 @@
+Scenario
+===========
+In this scenario, DAS will be connected to a JMS event publisher such as ActiveMQ by subscribing to a topic ex: "test_topic". Once an event payload is received from ActiveMQ, those events are then sent  to inStream_1.0.0. The events will be then processed within the execution planner where all events are collected for a time of one minute and push out after the event expire. The out stream will then save the data to an rdbms database table.
+
+Preconditions
+=============
+1.A Database should be created in mysql as below
+create table tbldata(meta_id int(10),correlation_id int(20),id int(10), username varchar (200));
+
+2.The Data Source should be configured within DAS
+
+3.ActiveMQ should be running
+
+4.ActiveMQ related Jars should be added to repository/components/lib path
+
+steps
+======
+1.add the event streams inStream_1.0.0.json and outStream_1.0.0.json to path <das-home>/repository/deployment/server/eventstreams
+
+2.add the event receiver ex: jms_event.xml to <das-home>/repository/deployment/server/eventreceiver
+
+3.add the rdbms.xml to <das-home>/repository/deployment/server/eventpublisher
+
+4.add the execution plan ExecutionPlan.siddhiql to <das-home>/repository/deployment/server/executionplans
+
+5.Access the topic test_topic in ActiveMQ and Submit a payload
+
+<events>
+    <event>
+        <metaData>
+            <id>100</id>
+        </metaData>
+        <correlationData>
+            <id>100</id>
+        </correlationData>
+        <payloadData>
+            <id>45</id>
+            <name>data3</name>
+        </payloadData>
+    </event>
+</events>
+
+6.check the db table for events for expired events.

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/ReadMe.txt~
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/ReadMe.txt~
@@ -1,0 +1,28 @@
+Scenario
+===========
+In this scenario, DAS will be connected to a JMS event publisher such as ActiveMQ by subscribing to a topic ex: "test_topic". Once an event payload is received from ActiveMQ, those events are then sent  to inStream_1.0.0. The events will be then processed within the execution planner where all events are collected for a time of one minute and push out after the event expire. The out stream will then save the data to an rdbms database table.
+
+Preconditions
+=============
+1.A Database should be created in mysql as below
+create table tbldata(meta_id int(10),correlation_id int(20),id int(10), username varchar (200));
+
+2.The Data Source should be configured within DAS
+
+3.ActiveMQ should be running
+
+4.ActiveMQ related Jars should be added to repository/components/lib path
+
+steps
+======
+1.add the event streams inStream_1.0.0.json and outStream_1.0.0.json to path <das-home>/repository/deployment/server/eventstreams
+
+2.add the event receiver ex: jms_event.xml to <das-home>/repository/deployment/server/eventreceiver
+
+3.add the rdbms.xml to <das-home>/repository/deployment/server/eventpublisher
+
+4.add the execution plan ExecutionPlan.siddhiql to <das-home>/repository/deployment/server/executionplans
+
+5.Access the topic test_topic in ActiveMQ and Submit a payload
+
+6.check the db table for events 

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventpublishers/rdbms.xml
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventpublishers/rdbms.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eventPublisher name="rdbms" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
+  <from streamName="outStream" version="1.0.0"/>
+  <mapping customMapping="disable" type="map"/>
+  <to eventAdapterType="rdbms">
+    <property name="datasource.name">DASDS</property>
+    <property name="update.keys">id</property>
+    <property name="execution.mode">update-or-insert</property>
+    <property name="table.name">tbldata</property>
+  </to>
+</eventPublisher>

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventreceivers/jms_event.xml
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventreceivers/jms_event.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<eventReceiver name="jms_event" statistics="disable" trace="disable" xmlns="http://wso2.org/carbon/eventreceiver">
+    <from eventAdapterType="jms">
+        <property name="transport.jms.DestinationType">topic</property>
+        <property name="transport.jms.Destination">test_topic</property>
+        <property name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</property>
+        <property name="java.naming.provider.url">tcp://localhost:61616</property>
+        <property name="transport.jms.SubscriptionDurable">false</property>
+        <property name="transport.jms.ConnectionFactoryJNDIName">TopicConnectionFactory</property>
+        <property encrypted="true" name="transport.jms.Password">kuv2MubUUveMyv6GeHrXr9il59ajJIqUI4eoYHcgGKf/BBFOWn96NTjJQI+wYbWjKW6r79S7L7ZzgYeWx7DlGbff5X3pBN2Gh9yV0BHP1E93QtFqR7uTWi141Tr7V7ZwScwNqJbiNoV+vyLbsqKJE7T3nP8Ih9Y6omygbcLcHzg=</property>
+        <property name="transport.jms.UserName">admin</property>
+    </from>
+    <mapping customMapping="disable" type="xml"/>
+    <to streamName="inStream" version="1.0.0"/>
+</eventReceiver>

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventstreams/inStream_1.0.0.json
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventstreams/inStream_1.0.0.json
@@ -1,0 +1,28 @@
+{
+  "name": "inStream",
+  "version": "1.0.0",
+  "nickName": "",
+  "description": "",
+  "metaData": [
+    {
+      "name": "id",
+      "type": "INT"
+    }
+  ],
+  "correlationData": [
+    {
+      "name": "id",
+      "type": "INT"
+    }
+  ],
+  "payloadData": [
+    {
+      "name": "id",
+      "type": "INT"
+    },
+    {
+      "name": "name",
+      "type": "STRING"
+    }
+  ]
+}

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventstreams/outStream_1.0.0.json
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/eventstreams/outStream_1.0.0.json
@@ -1,0 +1,28 @@
+{
+  "name": "outStream",
+  "version": "1.0.0",
+  "nickName": "",
+  "description": "",
+  "metaData": [
+    {
+      "name": "id",
+      "type": "INT"
+    }
+  ],
+  "correlationData": [
+    {
+      "name": "id",
+      "type": "INT"
+    }
+  ],
+  "payloadData": [
+    {
+      "name": "id",
+      "type": "INT"
+    },
+    {
+      "name": "userName",
+      "type": "STRING"
+    }
+  ]
+}

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/executionplans/ExecutionPlan.siddhiql
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/executionplans/ExecutionPlan.siddhiql
@@ -1,0 +1,22 @@
+/* Enter a unique ExecutionPlan */
+@Plan:name('ExecutionPlan')
+
+/* Enter a unique description for ExecutionPlan */
+-- @Plan:description('ExecutionPlan')
+
+/* define streams/tables and write queries here ... */
+
+
+
+
+@Import('inStream:1.0.0')
+define stream inStream (meta_id int, correlation_id int, id int, name string);
+
+@Export('outStream:1.0.0')
+define stream outStream (meta_id int, correlation_id int, id int, userName string);
+
+from inStream#window.time(1 min)
+select meta_id,correlation_id,id,convert(name, 'string') as userName
+insert expired events into outStream
+
+                    

--- a/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/executionplans/ExecutionPlan.siddhiql~
+++ b/products/wso2_DAS/product_features/data_aggregating/jms_event_receiver_to_rdbms_event_publisher/executionplans/ExecutionPlan.siddhiql~
@@ -1,0 +1,20 @@
+/* Enter a unique ExecutionPlan */
+@Plan:name('ExecutionPlan')
+
+/* Enter a unique description for ExecutionPlan */
+-- @Plan:description('ExecutionPlan')
+
+/* define streams/tables and write queries here ... */
+
+
+
+
+@Import('inStream:1.0.0')
+define stream inStream (meta_id int, correlation_id int, id int, name string);
+
+@Export('outStream:1.0.0')
+define stream outStream (meta_id int, correlation_id int, id int, userName string);
+
+from inStream#window.time(1 min)
+select meta_id,correlation_id,id,convert(name, 'string') as userName
+insert expired events into outStream


### PR DESCRIPTION
In this scenario, DAS will be connected to a JMS event publisher such as ActiveMQ by subscribing to a topic ex: "test_topic". Once an event payload is received from ActiveMQ, those events are then sent  to inStream_1.0.0. 

Within the execution plan, these events will be then processed where all events are collected for a time of one minute and push out after the event expire. The out stream will then save the data to an rdbms database table.
